### PR TITLE
fix scikit-learn joblib warning

### DIFF
--- a/nflwin/model.py
+++ b/nflwin/model.py
@@ -7,8 +7,9 @@ import numpy as np
 from scipy import integrate
 from scipy import stats
 
+import joblib
+
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.externals import joblib
 from sklearn.linear_model import LogisticRegression
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.cross_validation import train_test_split

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ CLASSIFIERS = [
 INSTALL_REQUIRES = ['numpy',
                     'scipy',
                     'pandas',
-                    'scikit-learn']
+                    'scikit-learn',
+                    'joblib',]
 
 EXTRAS_REQUIRE = {
     "plotting": ["matplotlib"],
@@ -47,7 +48,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 README = None
 with open(os.path.join(HERE, 'README.rst'),'r') as f:
     README = f.read()
-    
+
 ###################################################################
 
 if __name__ == "__main__":


### PR DESCRIPTION
`joblib` is split out as a separate dependency from `sklearn` going forward, per the error message when imported via `from sklearn.external import joblib`. This PR adds `joblib` as its own dependency, installed via `setup.py`.